### PR TITLE
Remove contact table join from UHT Search SQL

### DIFF
--- a/api/lib/gateways/UHT-HousingRegister/sql/searchCustomersBase.sql
+++ b/api/lib/gateways/UHT-HousingRegister/sql/searchCustomersBase.sql
@@ -12,5 +12,3 @@ FROM
 [dbo].[wlmember]
 JOIN [dbo].[wlapp] AS wlapp
 	ON wlmember.app_ref = wlapp.app_ref
-JOIN [dbo].[contacts] AS contacts
-	ON contacts.con_ref = wlapp.app_ref


### PR DESCRIPTION
For some customers not all of their application references were coming up in Single View. The problem was that the SQL query which searched for customers in the wlmember and wlapp tables also performed a join on the contacts table, which filtered some entries. 

One thing to note is that customers with double-barrelled names might be entered differently into the database (eg. **maria-smith** or **maria - smith**) and not all entries may be returned for that person. Could fix this by removing spaces next to dashes. 

