### PR TITLE
Allow all jigsaw documents to be opened/downloaded by checking mimeTypes

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -147,11 +147,14 @@ app.post('/customers/:id/vulnerabilities', async (req, res) => {
 });
 
 const getJigsawDoc = async event => {
-  const doc = await getJigsawDocument(event.pathParameters.jigsawDocId);
+  const { doc, mimeType } = await getJigsawDocument(
+    event.pathParameters.jigsawDocId,
+    event.pathParameters.customerId
+  );
   return {
     statusCode: 200,
     headers: {
-      'Content-Type': 'application/pdf',
+      'Content-Type': mimeType,
       'Content-Length': doc.length
     },
     body: doc.toString('base64'),

--- a/api/index.js
+++ b/api/index.js
@@ -145,9 +145,9 @@ app.post('/customers/:id/vulnerabilities', async (req, res) => {
   console.timeEnd('SAVING VULNERABILITY');
   res.send({ id });
 });
-
+const getJigsawDocDownloadTemplate = () => {};
 const getJigsawDoc = async event => {
-  const { doc, mimeType } = await getJigsawDocument(
+  const { doc, mimeType, filename } = await getJigsawDocument(
     event.pathParameters.jigsawDocId,
     event.pathParameters.customerId
   );
@@ -155,7 +155,8 @@ const getJigsawDoc = async event => {
     statusCode: 200,
     headers: {
       'Content-Type': mimeType,
-      'Content-Length': doc.length
+      'Content-Length': doc.length,
+      'Content-Disposition': `inline; filename="${filename}"`
     },
     body: doc.toString('base64'),
     isBase64Encoded: true

--- a/api/lib/Constants.js
+++ b/api/lib/Constants.js
@@ -28,8 +28,16 @@ const HousingBands = {
   GEN: 'General'
 };
 
+const MimeType = {
+  Default: 'application/octet-stream',
+  Html: 'text/html',
+  Pdf: 'application/pdf',
+  PlainText: 'text/plain'
+};
+
 module.exports = {
   Systems,
   IncomeFrequency,
-  HousingBands
+  HousingBands,
+  MimeType
 };

--- a/api/lib/entities/Document.js
+++ b/api/lib/entities/Document.js
@@ -1,8 +1,9 @@
 const { formatRecordDate } = require('../Utils');
 
 module.exports = () => {
-  return ({ id, title, text, date, user, system, format }) => {
+  return ({ userid, id, title, text, date, user, system, format }) => {
     return {
+      userid,
       id,
       title,
       text,

--- a/api/lib/gateways/Academy-Benefits/FetchDocuments.js
+++ b/api/lib/gateways/Academy-Benefits/FetchDocuments.js
@@ -21,6 +21,7 @@ module.exports = options => {
   const processDocuments = records => {
     return records.map(doc => {
       return buildDocument({
+        userid: null,
         id: doc.document_id,
         title: 'Academy Document',
         text: doc.correspondence_code,

--- a/api/lib/gateways/Comino/FetchDocuments.js
+++ b/api/lib/gateways/Comino/FetchDocuments.js
@@ -25,6 +25,7 @@ module.exports = options => {
   const processDocuments = documents => {
     return documents.map(doc => {
       return buildDocument({
+        userid: null,
         id: doc.DocNo,
         title: 'Document',
         text: doc.DocDesc + `${doc.title ? ' - ' + doc.title : ''}`,

--- a/api/lib/gateways/Jigsaw/FetchDocuments.js
+++ b/api/lib/gateways/Jigsaw/FetchDocuments.js
@@ -26,10 +26,10 @@ module.exports = options => {
       .flat();
   };
 
-  const processDocuments = documents => {
+  const processDocuments = (documents, userid) => {
     return documents.map(doc => {
       return buildDocument({
-        userid: doc.casePersonId,
+        userid,
         id: doc.id,
         title: 'Document',
         text: doc.name,
@@ -46,7 +46,7 @@ module.exports = options => {
       try {
         if (id) {
           const documents = await fetchCustomerDocuments(id);
-          return processDocuments(documents);
+          return processDocuments(documents, id);
         }
         return [];
       } catch (err) {

--- a/api/lib/gateways/UHW/FetchDocuments.js
+++ b/api/lib/gateways/UHW/FetchDocuments.js
@@ -16,6 +16,7 @@ module.exports = options => {
   const processDocuments = results => {
     return results.map(doc => {
       return buildDocument({
+        userid: null,
         id: doc.DocNo,
         title: 'Document',
         text: `${doc.DocDesc}${doc.title ? ' - ' + doc.title : ''}`,

--- a/api/lib/libDependencies.js
+++ b/api/lib/libDependencies.js
@@ -247,7 +247,8 @@ const addVulnerability = require('./use-cases/AddVulnerability')({
 });
 
 const getJigsawDocument = require('./use-cases/FetchJigsawDocument')({
-  jigsawDocGateway: fetchDocumentImage
+  jigsawDocGateway: fetchDocumentImage,
+  jigsawMetadataGateway: jigsawFetchDocumentsGateway
 });
 
 module.exports = {

--- a/api/lib/use-cases/FetchJigsawDocument.js
+++ b/api/lib/use-cases/FetchJigsawDocument.js
@@ -1,7 +1,23 @@
+const mimeTypes = require('mime-types');
+const { MimeType } = require('../Constants');
+
 module.exports = options => {
   const jigsawDocGateway = options.jigsawDocGateway;
+  const jigsawMetadataGateway = options.jigsawMetadataGateway;
 
-  return async id => {
-    return jigsawDocGateway.execute(id);
+  return async (id, userId) => {
+    const doc = await jigsawDocGateway.execute(id);
+    const metadata = await jigsawMetadataGateway.execute(userId);
+
+    let fileExt = MimeType.Default;
+    const intId = parseInt(id, 10);
+    metadata.forEach(m => {
+      if (m.id === intId) {
+        fileExt = m.format;
+      }
+    });
+
+    const mimeType = mimeTypes.lookup(fileExt) || MimeType.Default;
+    return { doc, mimeType };
   };
 };

--- a/api/lib/use-cases/FetchJigsawDocument.js
+++ b/api/lib/use-cases/FetchJigsawDocument.js
@@ -10,14 +10,16 @@ module.exports = options => {
     const metadata = await jigsawMetadataGateway.execute(userId);
 
     let fileExt = MimeType.Default;
+    let filename = 'download';
     const intId = parseInt(id, 10);
     metadata.forEach(m => {
       if (m.id === intId) {
         fileExt = m.format;
+        filename = m.text;
       }
     });
 
     const mimeType = mimeTypes.lookup(fileExt) || MimeType.Default;
-    return { doc, mimeType };
+    return { doc, mimeType, filename };
   };
 };

--- a/api/lib/use-cases/FetchJigsawDocument.js
+++ b/api/lib/use-cases/FetchJigsawDocument.js
@@ -15,7 +15,7 @@ module.exports = options => {
     metadata.forEach(m => {
       if (m.id === intId) {
         fileExt = m.format;
-        filename = m.text;
+        if (m.text) filename = m.text;
       }
     });
 

--- a/api/test/use-cases/GetJigsawDoc.test.js
+++ b/api/test/use-cases/GetJigsawDoc.test.js
@@ -26,7 +26,6 @@ describe('fetchJigsawDocument', () => {
           userid: '3',
           id: 2,
           title: 'Document',
-          text: 'ltters.docx',
           date: '2018-09-04 10:17:26',
           user: 'mr person',
           system: 'JIGSAW',
@@ -59,6 +58,17 @@ describe('fetchJigsawDocument', () => {
     it('can get a default mimeType', async () => {
       const { mimeType } = await fetchJigsawDocument(jigsawDocIdTwo, userId);
       expect(mimeType).toEqual('application/octet-stream');
+    });
+  });
+
+  describe('filename', async () => {
+    it('can get first filename', async () => {
+      const { filename } = await fetchJigsawDocument(jigsawDocId, userId);
+      expect(filename).toEqual('something.pdf');
+    });
+    it('can get a default filename', async () => {
+      const { filename } = await fetchJigsawDocument(jigsawDocIdTwo, userId);
+      expect(filename).toEqual('download');
     });
   });
 });

--- a/api/test/use-cases/GetJigsawDoc.test.js
+++ b/api/test/use-cases/GetJigsawDoc.test.js
@@ -1,4 +1,8 @@
 describe('fetchJigsawDocument', () => {
+  const jigsawDocId = 1;
+  const jigsawDocIdTwo = 2;
+  const userId = 3;
+
   let fetchJigsawDocument;
 
   beforeEach(() => {
@@ -6,14 +10,55 @@ describe('fetchJigsawDocument', () => {
       execute: jest.fn(() => [])
     };
 
+    jigsawMetadataGateway = {
+      execute: jest.fn(() => [
+        {
+          userid: '3',
+          id: 1,
+          title: 'Document',
+          text: 'something.pdf',
+          date: '2018-09-04 10:17:51',
+          user: 'mr person',
+          system: 'JIGSAW',
+          format: '.pdf'
+        },
+        {
+          userid: '3',
+          id: 2,
+          title: 'Document',
+          text: 'ltters.docx',
+          date: '2018-09-04 10:17:26',
+          user: 'mr person',
+          system: 'JIGSAW',
+          format: '.wrongtype'
+        }
+      ])
+    };
+
     fetchJigsawDocument = require('../../lib/use-cases/FetchJigsawDocument')({
-      jigsawDocGateway
+      jigsawDocGateway,
+      jigsawMetadataGateway
     });
   });
 
+  it('can query jigsaw fetch documents gateway for metadata with correct user ID', async () => {
+    await fetchJigsawDocument(jigsawDocId, userId);
+    expect(jigsawMetadataGateway.execute).toHaveBeenCalledWith(userId);
+  });
+
   it('can query document from jigsaw gateway with the correct document id', async () => {
-    const jigsawDocId = 1;
-    await fetchJigsawDocument(jigsawDocId);
+    await fetchJigsawDocument(jigsawDocId, userId);
     expect(jigsawDocGateway.execute).toHaveBeenCalledWith(jigsawDocId);
+  });
+
+  describe('mime type', async () => {
+    it('can get first mimeType', async () => {
+      const { mimeType } = await fetchJigsawDocument(jigsawDocId, userId);
+      expect(mimeType).toEqual('application/pdf');
+    });
+    it('can get a default mimeType', async () => {
+      const { mimeType } = await fetchJigsawDocument(jigsawDocIdTwo, userId);
+      expect(mimeType).toEqual('application/octet-stream');
+    });
   });
 });


### PR DESCRIPTION
Adds userid to the document structure. Userid is used to get metadata for jigsaw documents. All other gateways have null assigned to userid, cause they have to have something assigned (throws error otherwise). 
Metadata returns as an array of document metadata, then the id of the document being opened is found within that array and that metadata is used...
