### PR TITLE
Add jest to eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
     "browser": true,
     "commonjs": true,
     "es6": true,
-    "node": true
+    "node": true,
+    "jest": true
   },
   // "parser": "babel-eslint",
   "extends": ["eslint:recommended", "plugin:prettier/recommended"],


### PR DESCRIPTION
Removes eslint warnings from Jest's globals.