### PR TITLE
Displays jigsaw docs download template

### DIFF
--- a/jigsaw/index.js
+++ b/jigsaw/index.js
@@ -21,22 +21,42 @@ if (process.env.ENV === 'staging' || process.env.ENV === 'production') {
   });
 }
 
+docCanBeDisplayed = (queryStringParameters, mimeType) => {
+  return (
+    (queryStringParameters && queryStringParameters.download) ||
+    mimeType === 'application/pdf' ||
+    mimeType === 'image/jpeg' ||
+    mimeType === 'image/png' ||
+    mimeType === 'text/plain' ||
+    mimeType === 'application/xml'
+  );
+};
+
+buildResponse = (body, mimeType, encoded) => {
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': mimeType,
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true
+    },
+    body: body,
+    isBase64Encoded: encoded
+  };
+};
+
 module.exports.handler = async event => {
   try {
     const { doc, mimeType } = await getJigsawDocument(
       event.pathParameters.jigsawId,
       event.pathParameters.documentId
     );
-    return {
-      statusCode: 200,
-      headers: {
-        'Content-Type': mimeType,
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Credentials': true
-      },
-      body: doc.toString('base64'),
-      isBase64Encoded: true
-    };
+    if (docCanBeDisplayed(event.queryStringParameters, mimeType)) {
+      return buildResponse(doc.toString('base64'), mimeType, true);
+    } else {
+      const body = `<html><body><p>This document is not able to display in your browser. <a href='${event.path}?download=true'>Download it here</a></p></body></html>`;
+      return buildResponse(body, 'text/html', false);
+    }
   } catch (err) {
     console.log(err);
     Sentry.captureException(err);


### PR DESCRIPTION
Add this instead of downloading files without warning:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/54268893/80363423-1baf0a80-887c-11ea-8129-96d8f8378793.png">
